### PR TITLE
階層付きリストのデザイン変更

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 
+
 :root {
   --foreground: #ffffff;
   --background: #000000;
@@ -11,10 +12,6 @@ body {
   font-family: 'Inter', sans-serif;
   line-height: 1.6;
 }
-
-/* 既存のTailwind設定の後に追加 */
-
-
 
 /* ブログ記事のスタイル */
 .blog-article {
@@ -50,6 +47,13 @@ body {
   @apply list-disc pl-6 my-4 space-y-2;
 }
 
+/*段落付きリスト2階層目以降のスタイル*/
+.blog-article ul ul {
+  @apply list-[circle] pl-6 my-4 space-y-2;
+}
+
+
+/* 順序付きリストスタイル */
 .blog-article ol {
   @apply list-decimal pl-6 my-4 space-y-2;
 }


### PR DESCRIPTION
## 背景
Issues: https://github.com/zawa-kun/my-blog/issues/2
階層化された箇条書きの点（・）が以下のようになっているため、
階層化されていることが分かりやすくしたい。

## 実装したこと
- [x] `src/app/globals.css`の`.blog-article ul ul`のCSSを追加。

## 備考
2段目以降は白丸（◦）にように変更。
下記の形になる。
- hogehoge
    - hogehoge
